### PR TITLE
Capturing the object using _this to reference the object correctly inside write()

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var util = require('util'),
 
 var BrowserStackReporter = function(baseReporter, config, options = {}) {
 
+  var _this = this
   this.baseReporter = baseReporter
   this.config = config
   this.options = options
@@ -69,8 +70,8 @@ var BrowserStackReporter = function(baseReporter, config, options = {}) {
   function write(filename, xml) {
 
     var outputDir = "."
-    if (this.options && typeof this.options.outputDir == 'string') {
-      outputDir = this.options.outputDir
+    if (_this.options && typeof _this.options.outputDir == 'string') {
+      outputDir = _this.options.outputDir
     }
     outputDir = `${outputDir}/browserstack-reports`
 


### PR DESCRIPTION
As write(...) is called from a listener function, the context for "this" doesn't refer to the original reporter meaning that this.options will always be undefined. This leads to outputDir not being used and reports always ending up in _./browserstack-reports/_