### PR TITLE
Version change to 1.0.0 for release to npmjs of the wdio5 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # wdio-browserstack-reporter
 
-A WebdriverIO plugin for v5 and v6 which enables BrowserStack reports on CI servers. For v4 please refer to branch wdio4.
-
+The branch contains reporter for **WebdriverIO 5** and **WebdriverIO 6**, for v4 please refer to [wdio-browserstack-reporter/wdio4](https://github.com/browserstack/wdio-browserstack-reporter/tree/wdio4)
 ![Browserstack reports on Jenkins](screenshots/jenkins_report.png)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # wdio-browserstack-reporter
 
-A WebdriverIO plugin which enables BrowserStack reports on CI servers
+A WebdriverIO plugin for v5 and v6 which enables BrowserStack reports on CI servers. For v4 please refer to branch wdio4.
 
 ![Browserstack reports on Jenkins](screenshots/jenkins_report.png)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # wdio-browserstack-reporter
 
-The branch contains reporter for **WebdriverIO 5** and **WebdriverIO 6**, for v4 please refer to [wdio-browserstack-reporter/wdio4](https://github.com/browserstack/wdio-browserstack-reporter/tree/wdio4)
+The branch contains reporter for **WebdriverIO 5** and later versions. For earlier versions please refer to [wdio-browserstack-reporter/wdio4](https://github.com/browserstack/wdio-browserstack-reporter/tree/wdio4)
 ![Browserstack reports on Jenkins](screenshots/jenkins_report.png)
 
 ## Installation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-browserstack-reporter",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -15,9 +15,9 @@
       "integrity": "sha512-KTueBpPsmjfiyrAxxhKlEMwXb3aRmDHG5tRYwtRF3ujLQ7/e/5MH3b2p9ND2P84rU8z5dQq40vWJv6TtEdS16Q==",
       "requires": {
         "date-format": "0.0.2",
-        "lodash": "4.17.10",
-        "mkdirp": "0.5.1",
-        "xmlbuilder": "10.0.0"
+        "lodash": "^4.17.10",
+        "mkdirp": "^0.5.0",
+        "xmlbuilder": "^10.0.0"
       }
     },
     "lodash": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
       "integrity": "sha512-KTueBpPsmjfiyrAxxhKlEMwXb3aRmDHG5tRYwtRF3ujLQ7/e/5MH3b2p9ND2P84rU8z5dQq40vWJv6TtEdS16Q==",
       "requires": {
         "date-format": "0.0.2",
-        "lodash": "^4.17.10",
-        "mkdirp": "^0.5.0",
-        "xmlbuilder": "^10.0.0"
+        "lodash": "4.17.10",
+        "mkdirp": "0.5.1",
+        "xmlbuilder": "10.0.0"
       }
     },
     "lodash": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-browserstack-reporter",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "A WebdriverIO plugin which enables BrowserStack reports on CI servers",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "xmlbuilder": "^10.0.0"
   },
   "peerDependencies": {
-    "@wdio/cli": "^5.0.0"
+    "@wdio/cli": ">=5.0.0"
   }
 }


### PR DESCRIPTION
Setting version of wdio5 version to 1.1.0 to be released in npmjs. Peer dependency warning will be given when the user is using wdio4 currently and tries to install the wdio-browserstack-reporter of version 1.1.0.