### PR TITLE
Add projectType for Azure plugin wdio5

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add `wdio-browserstack-reporter` as a dependency in your `package.json`.
 ```json
 {
   "dependencies": {
-    "wdio-browserstack-reporter": "^1.0.0"
+    "wdio-browserstack-reporter": "browserstack/wdio-browserstack-reporter#wdio5"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add `wdio-browserstack-reporter` as a dependency in your `package.json`.
 ```json
 {
   "dependencies": {
-    "wdio-browserstack-reporter": "browserstack/wdio-browserstack-reporter#wdio5"
+    "wdio-browserstack-reporter": "1.0.1"
   }
 }
 ```

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ class BrowserStackReporter extends WdioReporter {
   prepareXml(runner) {
     let thisRunner = this;
     let sessionId = runner.sessionId;
+    let projectType = runner.capabilities && runner.capabilities.bundleID ? "APP_AUTOMATE" : "AUTOMATE";
 
     var xmlbuilder = require("xmlbuilder");
     const builder = xmlbuilder.create("testsuites", {
@@ -66,6 +67,7 @@ class BrowserStackReporter extends WdioReporter {
           index: 0
         });
         testCaseForXML.ele("session", {}, sessionId);
+        testCaseForXML.ele("projectType", {}, projectType); // This variable is required in Azure plugin for App Automate
       }
     }
     return builder.end({ pretty: true });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-browserstack-reporter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-browserstack-reporter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A WebdriverIO plugin which enables BrowserStack reports on CI servers",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Azure plugin never worked for App Automate since project Type as App automate was missing.
So that azure reporter can query right database 